### PR TITLE
SAI ACL Packet Resolution type meta data

### DIFF
--- a/inc/saiacl.h
+++ b/inc/saiacl.h
@@ -322,10 +322,16 @@ typedef enum _sai_acl_table_attr_t
     /** NPU Based Meta Data [bool] */
 
     /** DST MAC address match in FDB */
-    SAI_ACL_TABLE_ATTR_FIELD_FDB_DST_NPU_META_HIT,
+    SAI_ACL_TABLE_ATTR_FIELD_FDB_NPU_META_DST_HIT,
 
     /** DST IP address match in neighbor table */
-    SAI_ACL_TABLE_ATTR_FIELD_NEIGHBOR_DST_NPU_META_HIT,
+    SAI_ACL_TABLE_ATTR_FIELD_NEIGHBOR_NPU_META_DST_HIT,
+
+    /** DST IP address match in Route table [bool] */
+    SAI_ACL_TABLE_ATTR_FIELD_ROUTE_NPU_META_DST_HIT,
+
+    /** Packet Resolution type [sai_packet_resolution_t] */
+    SAI_ACL_TABLE_ATTR_FIELD_NPU_META_PACKET_RESOLUTION_TYPE,
 
     /** User Defined Field Groups [sai_object_id_t]
      * (CREATE_ONLY, default to SAI_NULL_OBJECT_ID) */
@@ -521,6 +527,12 @@ typedef enum _sai_acl_entry_attr_t
 
     /** DST IP address match in neighbor Table */
     SAI_ACL_ENTRY_ATTR_FIELD_NEIGHBOR_NPU_META_DST_HIT,
+
+    /** DST IP address match in Route Table [bool] */
+    SAI_ACL_ENTRY_ATTR_FIELD_ROUTE_NPU_META_DST_HIT,
+
+    /** Packet Resolution type [sai_packet_resolution_t] */
+    SAI_ACL_ENTRY_ATTR_FIELD_NPU_META_PACKET_RESOLUTION_TYPE,
 
     /** User Defined Field data for the UDF Groups in ACL Table.
      * [sai_u8_list_t] */

--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -178,6 +178,25 @@ typedef enum _sai_switch_restart_type_t
 } sai_switch_restart_type_t;
 
 /**
+ *  @brief Attribute data for packet resolution types.
+ */
+typedef enum _sai_packet_resolution_t
+{
+    /** L2 Unicast Packet type */
+    SAI_PACKET_L2_UNICAST,
+
+    /** L2 Broadcast Packet type */
+    SAI_PACKET_L2_BROADCAST,
+
+    /** L2 Multicast Packet type */
+    SAI_PACKET_L2_MULTICAST,
+
+    /** L3 Unicast Packet type */
+    SAI_PACKET_IP_UNICAST,
+
+} sai_packet_resolution_t;
+
+/**
 *  Attribute Id in sai_set_switch_attribute() and
 *  sai_get_switch_attribute() calls
 */

--- a/inc/saitypes.h
+++ b/inc/saitypes.h
@@ -326,6 +326,7 @@ typedef struct _sai_acl_field_data_t
      * Expected AND result using match mask above with packet field value where applicable.
      */
     union {
+        bool booldata;
         sai_uint8_t u8;
         sai_int8_t s8;
         sai_uint16_t u16;


### PR DESCRIPTION
Added SAI ACL attribute to match Route table Hit Meta Data and Packet Resolution type NPU Meta Data.

Defined Enumeration for Packet Resolution types.
